### PR TITLE
Fix "Share with Twitter" button

### DIFF
--- a/app/main/posts/views/share/share-menu.html
+++ b/app/main/posts/views/share/share-menu.html
@@ -31,7 +31,7 @@
                 <div class="listing-item-image">
                     <img class="icon" src="/img/twitter.png" alt="">
                 </div>
-                <h2 class="listing-item-title"><a target="_blank" ng-href="https://twitter.com/home?status={{shareUrlEncoded}}">Twitter</a></h2>
+                <h2 class="listing-item-title"><a target="_blank" ng-href="https://twitter.com/intent/tweet?url={{shareUrlEncoded}}">Twitter</a></h2>
             </div>
         </div>
 


### PR DESCRIPTION
Currently the link to share with twitter does not work because the url is wrong. I have solved the problem by changing the url, following the Twitter documentation at https://developer.twitter.com/en/docs/twitter-for-websites/tweet-button/overview

This pull request makes the following changes:

- Fix twitter url to share the POI proppertly in the share-menu html template.

Testing checklist:

- [ ] Try to share some POI with twitter 
- [ ] I certify that I ran my checklist

Fixes https://github.com/ushahidi/platform-client/issues/1468 .

Ping @ushahidi/platform
